### PR TITLE
adapt sanity check for msr/quality indicator to support M flag

### DIFF
--- a/libslink/msrecord.c
+++ b/libslink/msrecord.c
@@ -232,7 +232,8 @@ sl_msr_parse_size (SLlog *log, const char *msrecord, SLMSrecord **ppmsr,
   /* Sanity check for msr/quality indicator */
   if (msr->fsdh.dhq_indicator != 'D' &&
       msr->fsdh.dhq_indicator != 'R' &&
-      msr->fsdh.dhq_indicator != 'Q')
+      msr->fsdh.dhq_indicator != 'Q' &&
+      msr->fsdh.dhq_indicator != 'M' )
   {
     sl_log_rl (log, 2, 0, "record header/quality indicator unrecognized: %c\n",
                msr->fsdh.dhq_indicator);


### PR DESCRIPTION
Hi,

the current version of the libslink does not support the **M** quality indicator flag which has been introduced in 2007(SEED Manual page 9). This patch modifies the sanity check to support the flag as well.

Best regards,

Enrico