### PR TITLE
Determine actual SeedLink packet sizes at run time instead of hardcoding SeedLink packet sizes to the SLRECSIZE const at compile time

### DIFF
--- a/src/dsarchive.c
+++ b/src/dsarchive.c
@@ -231,8 +231,8 @@ ds_streamproc (DataStream **streamroot, char *pathformat, const SLMSrecord *msr,
         if (errno == ENOENT)
         {
           sl_log (0, 1, "Creating directory: %s\n", filename);
-#if defined(SLP_WIN)
-          if (mkdir (filename))
+#ifdef SLP_WIN
+          if (_mkdir (filename))
           {
             sl_log (0, 1, "ds_streamproc: mkdir(%s) %s\n", filename,
                     strerror (errno));
@@ -251,7 +251,7 @@ ds_streamproc (DataStream **streamroot, char *pathformat, const SLMSrecord *msr,
         }
         else
         {
-          sl_log (1, 0, "%d: access denied, %s\n", filename, strerror (errno));
+          sl_log (1, 0, "%s: access denied, %s\n", filename, strerror (errno));
           sl_strparse (NULL, NULL, &fnlist);
           return -1;
         }

--- a/src/slinktool.c
+++ b/src/slinktool.c
@@ -123,7 +123,7 @@ main (int argc, char **argv)
     ptype  = sl_packettype (slpack);
     seqnum = sl_sequence (slpack);
 
-    packet_handler ((char *)&slpack->msrecord, ptype, seqnum, SLRECSIZE);
+    packet_handler (slpack->msrecord, ptype, seqnum, slpack->reclen);
 
     if (statefile && stateint)
     {
@@ -194,14 +194,14 @@ packet_handler (char *msrecord, int packet_type, int seqnum, int packet_size)
   /* Process waveform data and send it on */
   if (packet_type == SLDATA)
   {
-    sl_log (1, 1, "%s, seq %d, Received %s blockette\n",
-            timestamp, seqnum, type[packet_type]);
+    sl_log (1, 1, "%s, seq %d, Received %s blockette of %d bytes\n",
+            timestamp, seqnum, type[packet_type], packet_size);
 
     /* Parse data record and print requested detail if any */
     if (psamples)
-      sl_msr_parse (slconn->log, msrecord, &msr, 1, 1);
+      sl_msr_parse_size (slconn->log, msrecord, &msr, 1, 1, packet_size);
     else
-      sl_msr_parse (slconn->log, msrecord, &msr, 1, 0);
+      sl_msr_parse_size (slconn->log, msrecord, &msr, 1, 0, packet_size);
 
     if (ppackets)
       sl_msr_print (slconn->log, msr, ppackets - 1);
@@ -225,12 +225,12 @@ packet_handler (char *msrecord, int packet_type, int seqnum, int packet_size)
   {
     int terminate;
 
-    sl_log (1, 1, "%s, seq %d, Received %s blockette\n",
-            timestamp, seqnum, type[packet_type]);
+    sl_log (1, 1, "%s, seq %d, Received %s blockette of %d bytes\n",
+            timestamp, seqnum, type[packet_type], packet_size);
 
     terminate = (packet_type == SLINFT);
 
-    sl_msr_parse (slconn->log, msrecord, &msr, 0, 0);
+    sl_msr_parse_size (slconn->log, msrecord, &msr, 0, 0, packet_size);
 
     if (info_handler (msr, terminate) == -2)
     {
@@ -247,8 +247,8 @@ packet_handler (char *msrecord, int packet_type, int seqnum, int packet_size)
   }
   else
   {
-    sl_log (1, 1, "%s, seq %d, Received %s blockette\n",
-            timestamp, seqnum, type[packet_type]);
+    sl_log (1, 1, "%s, seq %d, Received %s blockette of %d bytes\n",
+            timestamp, seqnum, type[packet_type], packet_size);
   }
 
   /* Write packet to dumpfile if defined */

--- a/src/slinktool.c
+++ b/src/slinktool.c
@@ -16,11 +16,11 @@
 #include <string.h>
 #include <time.h>
 
+#include <libslink.h>
+
 #ifndef SLP_WIN
 #include <signal.h>
 #endif
-
-#include <libslink.h>
 
 #include "archive.h"
 #include "slinkxml.h"
@@ -894,11 +894,11 @@ report_environ ()
   }
 } /* End of report_environ() */
 
-#ifndef SLP_WIN
 /***************************************************************************
  * term_handler:
  * Signal handler routine to set the termination flag.
  ***************************************************************************/
+#ifndef SLP_WIN
 static void
 term_handler (int sig)
 {

--- a/src/slinktool.c
+++ b/src/slinktool.c
@@ -118,7 +118,7 @@ main (int argc, char **argv)
     exit (ping_server (slconn));
 
   /* Loop with the connection manager */
-  while (sl_collect (slconn, &slpack))
+  while (sl_collect (slconn, &slpack) == SLPACKET)
   {
     ptype  = sl_packettype (slpack);
     seqnum = sl_sequence (slpack);


### PR DESCRIPTION
Good morning @chad-iris,

I’ve updated my [pull request](https://github.com/iris-edu/slinktool/pull/6) so that it now builds against [libslink 2020.048 or later](https://github.com/iris-edu/libslink/tree/develop).

**When will you release the next version of slinktool?**


Thank you very much for your efforts,

@yen-soon