### PR TITLE
Adding a log when new file is created

### DIFF
--- a/src/dsarchive.c
+++ b/src/dsarchive.c
@@ -399,6 +399,8 @@ ds_getstream (DataStream **streamroot, const SLMSrecord *msr,
       sl_log (1, 0, "opening new data stream file, %s\n", strerror (errno));
       return NULL;
     }
+    sl_log (0, 0, "New data stream file created: %s\n", filename);
+    fflush(stdout);
 
     setvbuf (foundstream->filep, NULL, _IONBF, 0);
   }

--- a/src/dsarchive.c
+++ b/src/dsarchive.c
@@ -392,6 +392,13 @@ ds_getstream (DataStream **streamroot, const SLMSrecord *msr,
   /* If no file is open, well, open it */
   if (foundstream->filep == NULL)
   {
+    int newfile = 0;   /* a marker to log new file creation */
+    if (access(filename, F_OK) != 0)
+    {
+      /* file doesn't exist, remind it */
+      newfile = 1;
+    }
+
     sl_log (0, 2, "Creating new data stream file\n");
 
     if ((foundstream->filep = fopen (filename, "ab")) == NULL)
@@ -399,8 +406,12 @@ ds_getstream (DataStream **streamroot, const SLMSrecord *msr,
       sl_log (1, 0, "opening new data stream file, %s\n", strerror (errno));
       return NULL;
     }
-    sl_log (0, 0, "New data stream file created: %s\n", filename);
-    fflush(stdout);
+    if (newfile == 1)
+    {
+      /* It's a new file, log it*/
+      sl_log (0, 0, "New data stream file created: %s\n", filename);
+      fflush(stdout);
+    }
 
     setvbuf (foundstream->filep, NULL, _IONBF, 0);
   }


### PR DESCRIPTION
This is a small patch in order to report in the logs when a new data strem file is created.
I proposed this patch because it helps us out in order to detect new files creation when inotify is not possible (i.e. when writing on NFS mounted devices).

It would be great to have this patch upstream.